### PR TITLE
Use an empty array for actions

### DIFF
--- a/src/dbusimp.c
+++ b/src/dbusimp.c
@@ -133,12 +133,6 @@ int _notif_send_notification(struct NotifyData *data)
                                           DBUS_TYPE_STRING_AS_STRING,
                                           &actions))
         goto oom;
-
-    tmp_string = "";
-    if (!dbus_message_iter_append_basic(&actions, DBUS_TYPE_STRING,
-                                        &tmp_string))
-        goto oom;
-
     if (!dbus_message_iter_close_container(&args, &actions))
         goto oom;
 


### PR DESCRIPTION
Thanks @nowrep for writing notify-desktop.

This patch should fix #1, although I have not tested it in Plasma 5. I was able to reproduce the crash in dunst and tracked it down to the code iterating through the actions array. dunst was assuming the actions array was of odd length (pairs of action and label, as according to the [specification](https://people.gnome.org/~mccann/docs/notification-spec/notification-spec-latest.html#id2780838)). Also, GNOME's notification-daemon would produce this message about the same thing:
```
** (notification-daemon:25638): WARNING **: Label not found for action . The protocol specifies that a label must follow an action in the actions array
```
So by removing the empty string from the actions array, dunst correctly handles the notification, and notification-daemon's warning goes away. It also works in xfce4-notifyd, although I couldn't reproduce a crash in xfce4-notifyd before this patch either.